### PR TITLE
fix: Remove trailing slash on all path-joining operations

### DIFF
--- a/src/lib/core/RouterEngine.svelte.test.ts
+++ b/src/lib/core/RouterEngine.svelte.test.ts
@@ -94,7 +94,7 @@ describe("RouterEngine", () => {
             // Assert.
             expect(basePath).toBe('/parent/child');
         });
-        test("Should preserve the trailing slash.", () => {
+        test("Should remove the trailing slash.", () => {
             // Arrange.
             const router = new RouterEngine();
             router.basePath = '/abc/';
@@ -103,7 +103,7 @@ describe("RouterEngine", () => {
             const basePath = router.basePath;
 
             // Assert.
-            expect(basePath).toBe('/abc/');
+            expect(basePath).toBe('/abc');
         });
     });
     describe('url', () => {

--- a/src/lib/core/RouterEngine.svelte.ts
+++ b/src/lib/core/RouterEngine.svelte.ts
@@ -47,12 +47,15 @@ function isRouterEngine(obj: unknown): obj is RouterEngine {
  */
 export function joinPaths(...paths: string[]) {
     const hasLeadingSlash = paths[0].startsWith('/');
-    const hasTrailingSlash = paths[paths.length - 1].endsWith('/');
     const result = paths.reduce((acc, path, index) => {
         const trimmedPath = (path ?? '').replace(/^\/|\/$/g, '');
         return acc + (index > 0 && !acc.endsWith('/') && trimmedPath.length > 0 ? '/' : '') + trimmedPath;
     }, hasLeadingSlash ? '/' : '');
-    return result + (hasTrailingSlash && result !== '/' ? '/' : '');
+    return noTrailingSlash(result);
+}
+
+function noTrailingSlash(path: string) {
+    return path !== '/' && path.endsWith('/') ? path.slice(0, -1) : path;
 }
 
 function routeInfoIsRegexInfo(info: unknown): info is RegexRouteInfo {
@@ -132,7 +135,7 @@ export class RouterEngine {
         return this.#routePatterns;
     }
 
-    #testPath = $derived.by(() => this.#hashId ? (location.hashPaths[this.#hashId] || '/') :this.url.pathname);
+    #testPath = $derived.by(() => noTrailingSlash(this.#hashId ? (location.hashPaths[this.#hashId] || '/') : this.url.pathname));
 
     #routeStatusData = $derived.by(() => {
         const routeStatus = {} as Record<string, RouteStatus>;


### PR DESCRIPTION
Fixes Route doesn't match if the only difference is the ending / #4

The `joinPaths` function now removes trailing slashes away when the result of joining forms a path with at least one segment.

The calculation for the test path removes any trailing slash as per the same rules above.