### PR TITLE
fix(Link): Make explicit replacement of empty string for current URL to support Sveltekit

### DIFF
--- a/src/lib/Link/Link.svelte
+++ b/src/lib/Link/Link.svelte
@@ -105,16 +105,14 @@
 		return result;
 	});
 	const isActive = $derived(isRouteActive(router, activeFor));
-	const calcHref = $derived(
-		calculateHref(
+	const calcHref = $derived(href === '' ? location.url.href : calculateHref(
 			{
 				hash: resolvedHash,
 				preserveQuery: calcPreserveQuery
 			},
 			calcPrependBasePath ? router?.basePath : undefined,
 			href
-		)
-	);
+		));
 
 	function handleClick(event: MouseEvent & { currentTarget: EventTarget & HTMLAnchorElement }) {
 		incomingOnclick?.(event);


### PR DESCRIPTION
The problem is Sveltekit, that loses the hash tags when doing shallow routing.

Issue logged:  https://github.com/sveltejs/kit/issues/14648

Since I have no idea if this will be fixed fast enough, this is the workaround.